### PR TITLE
version is stated twice causing a keyword error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=['openmdao.main', 'commonse', 'pbeam'],
     package_dir={'': 'src'},
     packages=['towerse'],
-    version = '0.1.2',
+  #  version = '0.1.2',
     license='Apache License, Version 2.0',
     dependency_links=['https://github.com/WISDEM/pBEAM/tarball/master#egg=pbeam',
         'https://github.com/WISDEM/CommonSE/tarball/master#egg=commonse'],


### PR DESCRIPTION
The compromised file is `setup.py`

    install url: package= TowerSE url=  http://github.com/WISDEM/TowerSE/tarball/0.1
    installing distribution from current directory as a 'develop' egg
      File "setup.py", line 15
        version = '0.1.2',
    SyntaxError: keyword argument repeated
    
    ERROR: command '/Users/kilojoules/Code/lcStudy/openmdao-0.10.3.2/bin/python setup.py develop -N' returned error code: 1
    subprocess returned  255
    plugin TowerSE FAILED to install correctly.